### PR TITLE
Fixed Apricorn Leaves Issue

### DIFF
--- a/Gravelmon2.0Java/fabric/src/main/java/drai/dev/gravelmon/fabric/CreativeTabsInit.java
+++ b/Gravelmon2.0Java/fabric/src/main/java/drai/dev/gravelmon/fabric/CreativeTabsInit.java
@@ -66,14 +66,14 @@ public class CreativeTabsInit {
         });
 
         ItemGroupEvents.modifyEntriesEvent(CobblemonItemGroups.getBLOCKS_KEY()).register(entries -> {
-            entries.addAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.DEEPSLATE_ASTRAL_STONE_ORE.get().asItem().getDefaultInstance());
-            entries.addAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.ASTRAL_STONE_ORE.get().asItem().getDefaultInstance());
-            entries.addAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.DEEPSLATE_AIR_STONE_ORE.get().asItem().getDefaultInstance());
-            entries.addAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
+            entries.addBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
                     GravelmonItems.AIR_STONE_ORE.get().asItem().getDefaultInstance());
+            entries.addBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.DEEPSLATE_AIR_STONE_ORE.get().asItem().getDefaultInstance());
+            entries.addBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.ASTRAL_STONE_ORE.get().asItem().getDefaultInstance());
+            entries.addBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.DEEPSLATE_ASTRAL_STONE_ORE.get().asItem().getDefaultInstance());
 
             entries.addBefore(CobblemonItems.MOON_STONE_ORE.asItem().getDefaultInstance(),
                     GravelmonItems.MYSTIC_STONE_ORE.get().asItem().getDefaultInstance());

--- a/Gravelmon2.0Java/forge/src/main/java/drai/dev/gravelmon/forge/CreativeTabInit.java
+++ b/Gravelmon2.0Java/forge/src/main/java/drai/dev/gravelmon/forge/CreativeTabInit.java
@@ -141,17 +141,17 @@ public class CreativeTabInit {
         }
 
         if(event.getTab() == CobblemonItemGroups.getBLOCKS()) {
-            event.getEntries().putAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.DEEPSLATE_ASTRAL_STONE_ORE.get().asItem().getDefaultInstance(),
+            event.getEntries().putBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.AIR_STONE_ORE.get().asItem().getDefaultInstance(),
                     CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
-            event.getEntries().putAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.ASTRAL_STONE_ORE.get().asItem().getDefaultInstance(),
-                    CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
-            event.getEntries().putAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
+            event.getEntries().putBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
                     GravelmonItems.DEEPSLATE_AIR_STONE_ORE.get().asItem().getDefaultInstance(),
                     CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
-            event.getEntries().putAfter(CobblemonItems.APRICORN_LEAVES.asItem().getDefaultInstance(),
-                    GravelmonItems.AIR_STONE_ORE.get().asItem().getDefaultInstance(),
+            event.getEntries().putBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.ASTRAL_STONE_ORE.get().asItem().getDefaultInstance(),
+                    CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
+            event.getEntries().putBefore(CobblemonItems.DAWN_STONE_ORE.asItem().getDefaultInstance(),
+                    GravelmonItems.DEEPSLATE_ASTRAL_STONE_ORE.get().asItem().getDefaultInstance(),
                     CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS);
 
 


### PR DESCRIPTION
Changed method to add in Air Stone and Astral Stone Ores to before Dawn Stone Ore instead of after apricorn leaves