### PR TITLE
Update porygon2.json

### DIFF
--- a/Gravelmon2.0Java/common/src/main/resources/data/cobblemon/species_additions/generation2/porygon2.json
+++ b/Gravelmon2.0Java/common/src/main/resources/data/cobblemon/species_additions/generation2/porygon2.json
@@ -16,6 +16,7 @@
   {
    "id": "porygon2_porygonx",
    "variant": "level_up",
+          "permanent": true,
    "result": "porygonx",
    "consumeHeldItem": true,
    "learnableMoves": [],
@@ -29,6 +30,7 @@
   {
    "id": "porygon2_porygonwes",
    "variant": "level_up",
+          "permanent": true,
    "result": "porygonwes",
    "consumeHeldItem": true,
    "learnableMoves": [],


### PR DESCRIPTION
added a ("permanent": true) method to the evolutions due to a change in the code that somehow made it not want to work for some odd reason. Only did it for Porygon2 since I'm only aware of it having this problem